### PR TITLE
Just replaced usage of deprecated misspelled method

### DIFF
--- a/src/main/java/omero/gateway/facility/SearchFacility.java
+++ b/src/main/java/omero/gateway/facility/SearchFacility.java
@@ -112,7 +112,7 @@ public class SearchFacility extends Facility {
                 // set general parameters
                 service.clearQueries();
                 service.setAllowLeadingWildcard(true);
-                service.setCaseSentivice(false);
+                service.setCaseSensitive(false);
                 String searchForClass = PojoMapper.convertTypeForSearch(type);
                 service.onlyType(searchForClass);
                 service.setBatchSize(batchSize);


### PR DESCRIPTION
Just replaces the usage of a deprecated, misspelled method of the Search service.
I think @mtbc already had a commit for that before the java gateway extraction from blitz happenend. Can't find it any more, so I just opened a new PR. 
/cc @jburel 
