### PR TITLE
Infinite pixel sizes

### DIFF
--- a/src/main/java/omero/gateway/model/PixelsData.java
+++ b/src/main/java/omero/gateway/model/PixelsData.java
@@ -256,7 +256,8 @@ public class PixelsData extends DataObject {
      */
     public Length getPixelSizeX(UnitsLength unit) throws BigResult {
         Length l = asPixels().getPhysicalSizeX();
-        if (l == null || l.getUnit().equals(UnitsLength.PIXEL))
+        if (l == null || l.getUnit().equals(UnitsLength.PIXEL)
+                || Double.isInfinite(l.getValue()) || Double.isNaN(l.getValue()))
             return null;
         return unit == null ? l : new LengthI(l, unit);
     }
@@ -286,7 +287,8 @@ public class PixelsData extends DataObject {
      */
     public Length getPixelSizeY(UnitsLength unit) throws BigResult {
         Length l = asPixels().getPhysicalSizeY();
-        if (l == null || l.getUnit().equals(UnitsLength.PIXEL))
+        if (l == null || l.getUnit().equals(UnitsLength.PIXEL)
+                || Double.isInfinite(l.getValue()) || Double.isNaN(l.getValue()))
             return null;
         return unit == null ? l : new LengthI(l, unit);
     }
@@ -316,7 +318,8 @@ public class PixelsData extends DataObject {
      */
     public Length getPixelSizeZ(UnitsLength unit) throws BigResult {
         Length l = asPixels().getPhysicalSizeZ();
-        if (l == null || l.getUnit().equals(UnitsLength.PIXEL))
+        if (l == null || l.getUnit().equals(UnitsLength.PIXEL)
+                || Double.isInfinite(l.getValue()) || Double.isNaN(l.getValue()))
             return null;
         return unit == null ? l : new LengthI(l, unit);
     }


### PR DESCRIPTION
Prevents that `Length` objects with infinite or nan value are returned from `getPixelSize` methods.
This can cause problems downstream (e.g in Insight).
See https://www.openmicroscopy.org/qa2/qa/feedback/27688/ or https://trello.com/c/X5egtRjc/3-iviewer-fails-to-load-images-with-pixel-size-nan-or-inf 

Test: Expand the dataset newproj1/newds1 as user-3 on eel (will crash Insight without the PR).

