### PR TITLE
Do not handle infinite, nan, etc. cases for pixel sizes

### DIFF
--- a/src/main/java/omero/gateway/model/PixelsData.java
+++ b/src/main/java/omero/gateway/model/PixelsData.java
@@ -256,8 +256,7 @@ public class PixelsData extends DataObject {
      */
     public Length getPixelSizeX(UnitsLength unit) throws BigResult {
         Length l = asPixels().getPhysicalSizeX();
-        if (l == null || l.getUnit().equals(UnitsLength.PIXEL)
-                || Double.isInfinite(l.getValue()) || Double.isNaN(l.getValue()))
+        if (l == null)
             return null;
         return unit == null ? l : new LengthI(l, unit);
     }
@@ -287,8 +286,7 @@ public class PixelsData extends DataObject {
      */
     public Length getPixelSizeY(UnitsLength unit) throws BigResult {
         Length l = asPixels().getPhysicalSizeY();
-        if (l == null || l.getUnit().equals(UnitsLength.PIXEL)
-                || Double.isInfinite(l.getValue()) || Double.isNaN(l.getValue()))
+        if (l == null)
             return null;
         return unit == null ? l : new LengthI(l, unit);
     }
@@ -318,8 +316,7 @@ public class PixelsData extends DataObject {
      */
     public Length getPixelSizeZ(UnitsLength unit) throws BigResult {
         Length l = asPixels().getPhysicalSizeZ();
-        if (l == null || l.getUnit().equals(UnitsLength.PIXEL)
-                || Double.isInfinite(l.getValue()) || Double.isNaN(l.getValue()))
+        if (l == null)
             return null;
         return unit == null ? l : new LengthI(l, unit);
     }


### PR DESCRIPTION
See PR title.
Reverts #14 and also removes the handling of the case where the pixel size unit is 'pixel'.
