### PR TITLE
Catch and treat omero.ClientError as connection lost issue

### DIFF
--- a/src/main/java/omero/gateway/facility/Facility.java
+++ b/src/main/java/omero/gateway/facility/Facility.java
@@ -327,7 +327,9 @@ public abstract class Facility {
                 || e instanceof TimeoutException
                 || cause instanceof ObjectNotExistException
                 || e instanceof ObjectNotExistException
-                || cause instanceof DNSException || e instanceof DNSException)
+                || cause instanceof DNSException
+                || e instanceof DNSException
+                || e instanceof omero.ClientError)
             return ConnectionStatus.LOST_CONNECTION;
         else if (cause instanceof CommunicatorDestroyedException
                 || e instanceof CommunicatorDestroyedException)


### PR DESCRIPTION
Catch and treat omero.ClientError as `CONNECTION_LOST` issue, so that clients like Insight can try to reconnect instead of throwing an exception.
See latest QA: https://www.openmicroscopy.org/qa2/qa/feedback/27714/ 
Or Trello card https://trello.com/c/HiWPqhG4/470-java-gateway-bugs 

**Test**:
Don't know. Does anyone know how to deliberately trigger an `omero.ClientError`?
