### PR TITLE
Disable unencrypted connection on fail

### DIFF
--- a/src/main/java/omero/gateway/Connector.java
+++ b/src/main/java/omero/gateway/Connector.java
@@ -790,7 +790,9 @@ class Connector
                 entryUnencrypted.keepAllAlive(null);
         } catch (Exception e) {
             success = false;
-            logger.warn(this, new LogMessage("failed unencrypted keep alive: ", e));
+            entryUnencrypted = null;
+            logger.warn(this, new LogMessage("failed unencrypted keep alive," +
+                    "disabling unencrypted connection", e));
         }
 
         if (success) {


### PR DESCRIPTION
Disables the 'unencrypted' connection if the keepalive fails, ie. successive calls to create import stores, etc. will fall back to use the encrypted connection. 

Reason for this is https://www.openmicroscopy.org/qa2/qa/feedback/27716/ which was very difficult to trace down. From the insight log:
```
2019-07-09 10:59:24,054 WARN  [                 omero.gateway.Connector] (2-thread-1) failed unencrypted keep alive: Ice.ConnectionLostException
```
Which means an initial 'unencrypted' connection must have been established successfully but then failed to stay alive, causing follow up errors when trying to import images. I think in these cases it'll be fine to fall back to use the encrypted connection. There will still be a warning about the issue logged.
