### PR TITLE
Support websocket URLs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    api("org.openmicroscopy:omero-blitz:5.5.3")
+    api("org.openmicroscopy:omero-blitz:5.5.4")
 
     implementation("commons-beanutils:commons-beanutils:1.9.3")
     implementation("com.zeroc:icegrid:3.6.4")

--- a/src/main/java/omero/gateway/Connector.java
+++ b/src/main/java/omero/gateway/Connector.java
@@ -23,7 +23,6 @@ package omero.gateway;
 
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -966,7 +965,7 @@ class Connector
                 session = prx.createSessionWithTimeouts(p, 0, timeout);
                 // Create the userSession
                 omero.client client = new omero.client(context
-                        .getServerInformation().getHostname(), context
+                        .getServerInformation().getHost(), context
                         .getServerInformation().getPort());
                 ServiceFactoryPrx userSession = client.createSession(session
                         .getUuid().getValue(), session.getUuid().getValue());

--- a/src/main/java/omero/gateway/Gateway.java
+++ b/src/main/java/omero/gateway/Gateway.java
@@ -24,7 +24,6 @@ package omero.gateway;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.net.InetAddress;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -304,7 +303,7 @@ public class Gateway implements AutoCloseable {
             throw new DSOutOfServiceException(e.getMessage(), e);
         } catch (DNSException e) {
             throw new DSOutOfServiceException("Can't resolve hostname "
-                    + c.getServer().getHostname(), e);
+                    + c.getServer().getHost(), e);
         }
     }
 
@@ -1064,10 +1063,10 @@ public class Gateway implements AutoCloseable {
         } else {
             username = c.getUser().getUsername();
             if (c.getServer().getPort() > 0)
-                secureClient = new client(c.getServer().getHostname(), c
+                secureClient = new client(c.getServer().getHost(), c
                         .getServer().getPort());
             else
-                secureClient = new client(c.getServer().getHostname());
+                secureClient = new client(c.getServer().getHost());
         }
         secureClient.setAgent(c.getApplicationName());
         ServiceFactoryPrx entryEncrypted = null;
@@ -1108,11 +1107,7 @@ public class Gateway implements AutoCloseable {
 
         if (c.isCheckNetwork()) {
             try {
-                String hn = c.getServer().getHostname();
-                // this could be a websocket URL
-                if (hn.contains("://"))
-                    hn = new URI(hn).getHost();
-                String ip = InetAddress.getByName(hn)
+                String ip = InetAddress.getByName(c.getServer().getHostname())
                         .getHostAddress();
                 networkChecker = new NetworkChecker(ip, log);
             } catch (Exception e) {
@@ -1707,7 +1702,7 @@ public class Gateway implements AutoCloseable {
                         args.toArray(new String[args.size()]));
                 prx = client.createSession();
             } else {
-                client = new client(login.getServer().getHostname(),
+                client = new client(login.getServer().getHost(),
                         login.getServer().getPort());
                 prx = client.createSession(login.getUser().getUsername(), login
                         .getUser().getPassword());

--- a/src/main/java/omero/gateway/Gateway.java
+++ b/src/main/java/omero/gateway/Gateway.java
@@ -24,6 +24,7 @@ package omero.gateway;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.net.InetAddress;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -1107,7 +1108,11 @@ public class Gateway implements AutoCloseable {
 
         if (c.isCheckNetwork()) {
             try {
-                String ip = InetAddress.getByName(c.getServer().getHostname())
+                String hn = c.getServer().getHostname();
+                // this could be a websocket URL
+                if (hn.contains("://"))
+                    hn = new URI(hn).getHost();
+                String ip = InetAddress.getByName(hn)
                         .getHostAddress();
                 networkChecker = new NetworkChecker(ip, log);
             } catch (Exception e) {

--- a/src/main/java/omero/gateway/LoginCredentials.java
+++ b/src/main/java/omero/gateway/LoginCredentials.java
@@ -67,10 +67,12 @@ public class LoginCredentials {
 
     /** Default websocket ports (this might be moved into omero.constants
      * in future) **/
-    private static Map<String,Integer> WS_PORTS = new HashMap<>();
-    static {
-        WS_PORTS.put("ws", 80);
-        WS_PORTS.put("wss", 443);
+    private enum DefaultPort {
+        WS(80), WSS(443);
+        private final int port;
+        DefaultPort(int port) {
+            this.port = port;
+        }
     }
 
     /**
@@ -139,9 +141,12 @@ public class LoginCredentials {
             if (!server.isURL()) {
                 server.setPort(omero.constants.GLACIER2PORT.value);
             }
-            else if (server.getPort() < 0 &&
-                    WS_PORTS.containsKey(server.getProtocol())) {
-                server.setPort(WS_PORTS.get(server.getProtocol()));
+            else if (server.getPort() < 0) {
+                try {
+                    server.setPort(DefaultPort.valueOf(server.getProtocol().toUpperCase()).port);
+                } catch (IllegalArgumentException e) {
+                    // neither ws nor wss
+                }
             }
         }
     }

--- a/src/main/java/omero/gateway/LoginCredentials.java
+++ b/src/main/java/omero/gateway/LoginCredentials.java
@@ -129,7 +129,7 @@ public class LoginCredentials {
             if (!server.isURL()) {
                 server.setPort(omero.constants.GLACIER2PORT.value);
             }
-            else if(server.getPort() < 0) {
+            else if (server.getPort() < 0) {
                 server.setPort(443);
             }
         }

--- a/src/main/java/omero/gateway/LoginCredentials.java
+++ b/src/main/java/omero/gateway/LoginCredentials.java
@@ -120,11 +120,11 @@ public class LoginCredentials {
         this();
         user.setUsername(username);
         user.setPassword(password);
-        server.setHostname(host);
+        server.setHost(host);
         if (port >= 0) {
             server.setPort(port);
         }
-        else {
+        else if (server.getPort() < 0) {
             // set default ports
             if (!server.isURL()) {
                 server.setPort(omero.constants.GLACIER2PORT.value);

--- a/src/main/java/omero/gateway/LoginCredentials.java
+++ b/src/main/java/omero/gateway/LoginCredentials.java
@@ -96,10 +96,10 @@ public class LoginCredentials {
      * @param password
      *            The password
      * @param host
-     *            The server hostname
+     *            The server hostname or websocket URL
      */
     public LoginCredentials(String username, String password, String host) {
-        this(username, password, host, omero.constants.GLACIER2PORT.value);
+        this(username, password, host, -1);
     }
 
     /**
@@ -111,7 +111,7 @@ public class LoginCredentials {
      * @param password
      *            The password
      * @param host
-     *            The server hostname
+     *            The server hostname or websocket URL
      * @param port
      *            The server port
      */
@@ -121,7 +121,18 @@ public class LoginCredentials {
         user.setUsername(username);
         user.setPassword(password);
         server.setHostname(host);
-        server.setPort(port);
+        if (port >= 0) {
+            server.setPort(port);
+        }
+        else {
+            // set default ports
+            if (!server.isURL()) {
+                server.setPort(omero.constants.GLACIER2PORT.value);
+            }
+            else if(server.getPort() < 0) {
+                server.setPort(443);
+            }
+        }
     }
 
     /**

--- a/src/main/java/omero/gateway/LoginCredentials.java
+++ b/src/main/java/omero/gateway/LoginCredentials.java
@@ -20,7 +20,9 @@
  */
 package omero.gateway;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import omero.IllegalArgumentException;
 
@@ -62,6 +64,14 @@ public class LoginCredentials {
 
     /** Whether to check the client-server versions */
     private boolean checkVersion = true;
+
+    /** Default websocket ports (this might be moved into omero.constants
+     * in future) **/
+    private static Map<String,Integer> WS_PORTS = new HashMap<>();
+    static {
+        WS_PORTS.put("ws", 80);
+        WS_PORTS.put("wss", 443);
+    }
 
     /**
      * Creates a new instance
@@ -129,8 +139,9 @@ public class LoginCredentials {
             if (!server.isURL()) {
                 server.setPort(omero.constants.GLACIER2PORT.value);
             }
-            else if (server.getPort() < 0) {
-                server.setPort(443);
+            else if (server.getPort() < 0 &&
+                    WS_PORTS.containsKey(server.getProtocol())) {
+                server.setPort(WS_PORTS.get(server.getProtocol()));
             }
         }
     }

--- a/src/main/java/omero/gateway/ServerInformation.java
+++ b/src/main/java/omero/gateway/ServerInformation.java
@@ -99,6 +99,24 @@ public class ServerInformation {
     }
 
     /**
+     * Set the hostname or websocket URL
+     *
+     * @param host
+     *            See above
+     */
+    public void setHost(String host) {
+        try {
+            if ((new URI(host)).isAbsolute())
+                // this is already a URI like wss://example.org
+                this.uri = new URI(host);
+            else
+                this.uri = new URI(uri.getScheme(), uri.getUserInfo(), host,
+                        uri.getPort(), uri.getPath(), uri.getQuery(), uri.getFragment());
+        } catch (URISyntaxException e) {
+        }
+    }
+
+    /**
      * Return the hostname. Even if a websocket URL
      * was specified only the hostname part will
      * be returned by this method. Use {@link #getHost()}
@@ -111,21 +129,15 @@ public class ServerInformation {
     }
 
     /**
+     * @deprecated Renamed to {@link #setHost(String)}
+     *
      * Set the hostname or websocket URL
      * 
      * @param hostname
      *            See above
      */
     public void setHostname(String hostname) {
-        try {
-            if ((new URI(hostname)).isAbsolute())
-                // this is already a URI like wss://example.org
-                this.uri = new URI(hostname);
-            else
-                this.uri = new URI(uri.getScheme(), uri.getUserInfo(), hostname,
-                        uri.getPort(), uri.getPath(), uri.getQuery(), uri.getFragment());
-        } catch (URISyntaxException e) {
-        }
+        setHost(hostname);
     }
 
     /**

--- a/src/main/java/omero/gateway/ServerInformation.java
+++ b/src/main/java/omero/gateway/ServerInformation.java
@@ -207,17 +207,4 @@ public class ServerInformation {
     public String toString() {
         return "ServerInformation [uri=" + uri.toString() + "]";
     }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ServerInformation that = (ServerInformation) o;
-        return uri.equals(that.uri);
-    }
-
-    @Override
-    public int hashCode() {
-        return uri.hashCode();
-    }
 }

--- a/src/main/java/omero/gateway/ServerInformation.java
+++ b/src/main/java/omero/gateway/ServerInformation.java
@@ -150,6 +150,15 @@ public class ServerInformation {
         }
     }
 
+    /**
+     * Returns <code>true</code> if a websocket
+     * URL was specified.
+     * @return See above.
+     */
+    public boolean isURL() {
+        return this.uri.isAbsolute();
+    }
+
     @Override
     public String toString() {
         return "ServerInformation [uri=" + uri.toString() + "]";

--- a/src/main/java/omero/gateway/ServerInformation.java
+++ b/src/main/java/omero/gateway/ServerInformation.java
@@ -20,8 +20,11 @@
  */
 package omero.gateway;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 /**
- * Holds hostname and port of an OMERO server
+ * Holds the network connection information of an OMERO server
  * 
  * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
  *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
@@ -30,49 +33,95 @@ package omero.gateway;
 
 public class ServerInformation {
 
-    /** The hostname */
-    private String hostname;
-
-    /** The port */
-    private int port;
+    /** The URI */
+    private URI uri;
 
     /**
      * Creates an empty instance
      */
     public ServerInformation() {
+        try {
+            this.uri = new URI(null, null, null,
+                    -1, null, null, null);
+        } catch (URISyntaxException e) {
+        }
+    }
 
+    /**
+     * Creates a new instance
+     *
+     * @param hostname
+     *            The hostname or websocket URL
+     */
+    public ServerInformation(String hostname) {
+        this(hostname, -1);
     }
 
     /**
      * Creates a new instance
      * 
      * @param hostname
-     *            The hostname
+     *            The hostname or websocket URL
      * @param port
      *            The port
      */
     public ServerInformation(String hostname, int port) {
-        super();
-        this.hostname = hostname;
-        this.port = port;
+        try {
+            if ((new URI(hostname)).isAbsolute()) {
+                // this is already a URI like wss://example.org
+                this.uri = new URI(hostname);
+                if (port < 0) {
+                    this.uri = new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(),
+                            port, uri.getPath(), uri.getQuery(), uri.getFragment());
+                }
+            }
+            else {
+                this.uri = new URI(null,null, hostname,
+                        port, null, null, null);
+            }
+        } catch (URISyntaxException e) {
+        }
+    }
+
+    /**
+     * Get the host information as required by the omero.client.
+     * In case a websocket URL was specified the full
+     * URL will be returned. If only a host name was
+     * specified only the host name will be returned.
+     * @return See above.
+     */
+    public String getHost() {
+        if (this.uri.isAbsolute())
+            return this.uri.toString();
+        else
+            return this.uri.getHost();
     }
 
     /**
      * Return the hostname.
+     *
      * @return The hostname
      */
     public String getHostname() {
-        return hostname;
+        return uri.getHost();
     }
 
     /**
-     * Set the hostname
+     * Set the hostname or websocket URL
      * 
      * @param hostname
      *            See above
      */
     public void setHostname(String hostname) {
-        this.hostname = hostname;
+        try {
+            if ((new URI(hostname)).isAbsolute())
+                // this is already a URI like wss://example.org
+                this.uri = new URI(hostname);
+            else
+                this.uri = new URI(uri.getScheme(), uri.getUserInfo(), hostname,
+                        uri.getPort(), uri.getPath(), uri.getQuery(), uri.getFragment());
+        } catch (URISyntaxException e) {
+        }
     }
 
     /**
@@ -80,7 +129,7 @@ public class ServerInformation {
      * @return The port
      */
     public int getPort() {
-        return port;
+        return uri.getPort();
     }
 
     /**
@@ -90,43 +139,16 @@ public class ServerInformation {
      *            See above
      */
     public void setPort(int port) {
-        this.port = port;
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result
-                + ((hostname == null) ? 0 : hostname.hashCode());
-        result = prime * result + port;
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        ServerInformation other = (ServerInformation) obj;
-        if (hostname == null) {
-            if (other.hostname != null)
-                return false;
-        } else if (!hostname.equals(other.hostname))
-            return false;
-        if (port != other.port)
-            return false;
-        return true;
+        try {
+            this.uri = new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(),
+                    port, uri.getPath(), uri.getQuery(), uri.getFragment());
+        } catch (URISyntaxException e) {
+        }
     }
 
     @Override
     public String toString() {
-        return "ServerInformation [hostname=" + hostname + ", port=" + port
-                + "]";
+        return "ServerInformation [uri=" + uri.toString() + "]";
     }
-
     
 }

--- a/src/main/java/omero/gateway/ServerInformation.java
+++ b/src/main/java/omero/gateway/ServerInformation.java
@@ -68,7 +68,7 @@ public class ServerInformation {
      */
     public ServerInformation(String hostname, int port) {
         try {
-            if ((new URI(hostname)).isAbsolute()) {
+            if (hostname.contains(":/")) {
                 // this is already a URI like wss://example.org
                 this.uri = new URI(hostname);
                 if (port >= 0 && this.uri.getPort() < 0) {
@@ -77,6 +77,13 @@ public class ServerInformation {
                 }
             }
             else {
+                if (port < 0 && hostname.contains(":")) {
+                    try {
+                        String[] parts = hostname.split(":");
+                        port = Integer.parseInt(parts[parts.length-1]);
+                        hostname = parts[parts.length-2];
+                    } catch (Exception e) {}
+                }
                 this.uri = new URI(null,null, hostname,
                         port, null, null, null);
             }
@@ -106,12 +113,22 @@ public class ServerInformation {
      */
     public void setHost(String host) {
         try {
-            if ((new URI(host)).isAbsolute())
+            if (host.contains(":/")) {
                 // this is already a URI like wss://example.org
                 this.uri = new URI(host);
-            else
+            }
+            else {
+                int port = uri.getPort();
+                if (port < 0 && host.contains(":")) {
+                    try {
+                        String[] parts = host.split(":");
+                        port = Integer.parseInt(parts[parts.length-1]);
+                        host = parts[parts.length-2];
+                    } catch (Exception e) {}
+                }
                 this.uri = new URI(uri.getScheme(), uri.getUserInfo(), host,
-                        uri.getPort(), uri.getPath(), uri.getQuery(), uri.getFragment());
+                        port, uri.getPath(), uri.getQuery(), uri.getFragment());
+            }
         } catch (URISyntaxException e) {
         }
     }

--- a/src/main/java/omero/gateway/ServerInformation.java
+++ b/src/main/java/omero/gateway/ServerInformation.java
@@ -22,6 +22,7 @@ package omero.gateway;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Objects;
 
 /**
  * Holds the network connection information of an OMERO server
@@ -150,5 +151,17 @@ public class ServerInformation {
     public String toString() {
         return "ServerInformation [uri=" + uri.toString() + "]";
     }
-    
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ServerInformation that = (ServerInformation) o;
+        return uri.equals(that.uri);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uri);
+    }
 }

--- a/src/main/java/omero/gateway/ServerInformation.java
+++ b/src/main/java/omero/gateway/ServerInformation.java
@@ -71,7 +71,7 @@ public class ServerInformation {
             if ((new URI(hostname)).isAbsolute()) {
                 // this is already a URI like wss://example.org
                 this.uri = new URI(hostname);
-                if (port < 0) {
+                if (port >= 0 && this.uri.getPort() < 0) {
                     this.uri = new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(),
                             port, uri.getPath(), uri.getQuery(), uri.getFragment());
                 }
@@ -100,7 +100,7 @@ public class ServerInformation {
 
     /**
      * Return the hostname. Even if a websocket URL
-     * URL was specified only the hostname part will
+     * was specified only the hostname part will
      * be returned by this method. Use {@link #getHost()}
      * to get the full websocket URL.
      *

--- a/src/main/java/omero/gateway/ServerInformation.java
+++ b/src/main/java/omero/gateway/ServerInformation.java
@@ -114,7 +114,12 @@ public class ServerInformation {
         try {
             if (host.contains(":/")) {
                 // this is already a URI like wss://example.org
+                int port = this.uri.getPort();
                 this.uri = new URI(host);
+                if (port >= 0 && this.uri.getPort() < 0) {
+                    this.uri = new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(),
+                            port, uri.getPath(), uri.getQuery(), uri.getFragment());
+                }
             }
             else {
                 int port = uri.getPort();

--- a/src/main/java/omero/gateway/ServerInformation.java
+++ b/src/main/java/omero/gateway/ServerInformation.java
@@ -101,8 +101,7 @@ public class ServerInformation {
     public String getHost() {
         if (this.uri.isAbsolute())
             return this.uri.toString();
-        else
-            return this.uri.getHost();
+        return this.uri.getHost();
     }
 
     /**

--- a/src/main/java/omero/gateway/ServerInformation.java
+++ b/src/main/java/omero/gateway/ServerInformation.java
@@ -99,7 +99,10 @@ public class ServerInformation {
     }
 
     /**
-     * Return the hostname.
+     * Return the hostname. Even if a websocket URL
+     * URL was specified only the hostname part will
+     * be returned by this method. Use {@link #getHost()}
+     * to get the full websocket URL.
      *
      * @return The hostname
      */

--- a/src/main/java/omero/gateway/ServerInformation.java
+++ b/src/main/java/omero/gateway/ServerInformation.java
@@ -22,7 +22,6 @@ package omero.gateway;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Objects;
 
 /**
  * Holds the network connection information of an OMERO server

--- a/src/main/java/omero/gateway/ServerInformation.java
+++ b/src/main/java/omero/gateway/ServerInformation.java
@@ -188,7 +188,7 @@ public class ServerInformation {
     }
 
     /**
-     * Returns the protocol if a websocket URL was specified
+     * Returns the protocol (lower case) if a websocket URL was specified
      * (empty String otherwise).
      * @return See above.
      */
@@ -213,6 +213,6 @@ public class ServerInformation {
 
     @Override
     public int hashCode() {
-        return Objects.hash(uri);
+        return uri.hashCode();
     }
 }

--- a/src/main/java/omero/gateway/ServerInformation.java
+++ b/src/main/java/omero/gateway/ServerInformation.java
@@ -187,6 +187,17 @@ public class ServerInformation {
         return this.uri.isAbsolute();
     }
 
+    /**
+     * Returns the protocol if a websocket URL was specified
+     * (empty String otherwise).
+     * @return See above.
+     */
+    public String getProtocol() {
+        if (isURL())
+            return this.uri.getScheme().toLowerCase();
+        return "";
+    }
+
     @Override
     public String toString() {
         return "ServerInformation [uri=" + uri.toString() + "]";


### PR DESCRIPTION
Websocket connection works in principle, but at the moment you'll get a "Failed to get inet address...." warning when the gateway tries to get the IP of the server. This PR just fixes the issue.

Test with something like this, e.g. against idr next ( this would implicitly also test https://github.com/ome/omero-blitz/pull/66 ):
```
public static void main(String... args) throws Exception {
        LoginCredentials cred = new LoginCredentials("USERNAME",
                "PASSWORD",
                "wss://[OMERO SERVER]/omero-ws", 443);
        Gateway gateway = new Gateway(new SimpleLogger());
        ExperimenterData user = gateway.connect(cred);
        System.out.println("Logged in as "+user.getUserName());
        gateway.disconnect();
    }
```
Then also test the 'normal' login via hostname only, and hostname + port.