### PR TITLE
Relax server version check for >=5.5 semantic versioning.

### DIFF
--- a/src/main/java/omero/gateway/Gateway.java
+++ b/src/main/java/omero/gateway/Gateway.java
@@ -89,6 +89,7 @@ import Glacier2.PermissionDeniedException;
 import Ice.DNSException;
 import Ice.SocketException;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
@@ -1197,8 +1198,8 @@ public class Gateway implements AutoCloseable {
             return serverMinor >= 5 && clientMinor >= 5;
         } catch (NumberFormatException nfe) {
             log.warn(this, String.format(
-                    "cannot compare server version %s.%s with client version %s.%s, assuming incompatible",
-                    server[0], server[1], client[0], client[1]));
+                    "cannot compare server version %s with client version %s, assuming incompatible",
+                    Joiner.on('.').join(server), Joiner.on('.').join(client)));
             return false;
         }
     }

--- a/src/main/java/omero/gateway/Gateway.java
+++ b/src/main/java/omero/gateway/Gateway.java
@@ -1157,6 +1157,8 @@ public class Gateway implements AutoCloseable {
 
     /**
      * Test if server and client versions are compatible.
+     * Versions are provided as separate components with separators omitted,
+     * the more significant at lower array indices so the major number is at index zero.
      * Not {@code private} only to allow unit testing.
      * @param server server version, no {@code null}s
      * @param client client version, no {@code null}s

--- a/src/main/java/omero/gateway/Gateway.java
+++ b/src/main/java/omero/gateway/Gateway.java
@@ -1160,7 +1160,7 @@ public class Gateway implements AutoCloseable {
      * Test if server and client versions are compatible.
      * Versions are provided as separate components with separators omitted,
      * the more significant at lower array indices so the major number is at index zero.
-     * Not {@code private} only to allow unit testing.
+     * Not {@code private} only to allow unit testing so not supported API.
      * @param server server version, no {@code null}s
      * @param client client version, no {@code null}s
      * @return if they are compatible

--- a/src/main/java/omero/gateway/Gateway.java
+++ b/src/main/java/omero/gateway/Gateway.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015-2018 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2019 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -1154,7 +1154,53 @@ public class Gateway implements AutoCloseable {
         }
         return true;
     }
-    
+
+    /**
+     * Test if server and client versions are compatible.
+     * Not {@code private} only to allow unit testing.
+     * @param server server version, no {@code null}s
+     * @param client client version, no {@code null}s
+     * @return if they are compatible
+     */
+    boolean isCompatibleVersion(String[] server, String[] client) {
+        if (server.length < 1 || client.length < 1) {
+            return true;
+        }
+        /* Major versions present so compare. */
+        if (!server[0].equals(client[0])) {
+            /* Major version does not match. */
+            return false;
+        }
+        if (server.length < 2 || client.length < 2) {
+            return true;
+        }
+        /* Minor versions present so compare. */
+        if (server[1].equals(client[1])) {
+            /* Minor version matches. */
+            return true;
+        }
+        /* Major version matches, minor version does not match. */
+        try {
+            final int major = Integer.parseUnsignedInt(server[0]);
+            if (major < 5) {
+                /* Server and client are earlier than 5.0 so minor difference is breaking. */
+                return false;
+            } else if (major > 5) {
+                /* Server and client are 6.0 or later so minor difference is not breaking. */
+                return true;
+            }
+            /* Minor difference is breaking only before 5.5. */
+            final int serverMinor = Integer.parseUnsignedInt(server[1]);
+            final int clientMinor = Integer.parseUnsignedInt(client[1]);
+            return serverMinor >= 5 && clientMinor >= 5;
+        } catch (NumberFormatException nfe) {
+            log.warn(this, String.format(
+                    "cannot compare server version %s.%s with client version %s.%s, assuming incompatible",
+                    server[0], server[1], client[0], client[1]));
+            return false;
+        }
+    }
+
     /**
      * Logs in a certain user
      * 
@@ -1183,7 +1229,7 @@ public class Gateway implements AutoCloseable {
                     && cred.getCheckVersion()) {
                 String[] vc = clientVersion.split("\\.");
                 String[] vs = serverVersion.split("\\.");
-                if (!vc[0].equals(vs[0]) || !vc[1].equals(vs[1]))
+                if (!isCompatibleVersion(vs, vc))
                     throw new DSOutOfServiceException("Client version "
                             + clientVersion
                             + " is not compatible with server version "

--- a/src/test/java/omero/gateway/GatewayTest.java
+++ b/src/test/java/omero/gateway/GatewayTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2019 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package omero.gateway;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import omero.log.SimpleLogger;
+
+/**
+ * Unit tests for the Java Gateway.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.5.5
+ */
+@Test(groups = "unit")
+public class GatewayTest {
+
+    private final Gateway gateway = new Gateway(new SimpleLogger());
+
+    /**
+     * @param major major version
+     * @param minor minor version
+     * @return if semantic versioning applies for that version
+     */
+    private boolean isSemanticVersioning(String major, String minor) {
+        switch (major) {
+        case "A":
+        case "4":
+            return false;
+        case "5":
+            switch (minor) {
+            case "A":
+            case "4":
+                return false;
+            case "5":
+            case "6":
+                return true;
+            }
+        case "6":
+            return true;
+        }
+        Assert.fail("unexpected");
+        return false;
+    }
+
+    /**
+     * Check that server-client compatibility is determined correctly for the given version numbers.
+     * @param serverMajor server major version
+     * @param serverMinor server minor version
+     * @param clientMajor client major version
+     * @param clientMinor client minor version
+     */
+    @Test(dataProvider = "version combinations")
+    public void testVersionCombination(String serverMajor, String serverMinor, String clientMajor, String clientMinor) {
+        final boolean isCompatibleVersion;
+        if (isSemanticVersioning(serverMajor, serverMinor) && isSemanticVersioning(clientMajor, clientMinor)) {
+            isCompatibleVersion = serverMajor.equals(clientMajor);
+        } else {
+            isCompatibleVersion = serverMajor.equals(clientMajor) && serverMinor.equals(clientMinor);
+        }
+        final String[] serverVersion = new String[] {serverMajor, serverMinor};
+        final String[] clientVersion = new String[] {clientMajor, clientMinor};
+        Assert.assertEquals(gateway.isCompatibleVersion(serverVersion, clientVersion), isCompatibleVersion);
+    }
+
+    /**
+     * @return test cases for {@link #testVersionCombination(String, String, String, String)}
+     */
+    @DataProvider(name = "version combinations")
+    public Object[][] provide() {
+        final List<String> versions = ImmutableList.of("4", "5", "6", "A");
+        return Lists.cartesianProduct(Collections.nCopies(4, versions))
+                .stream().map(args -> args.stream().toArray(String[]::new)).toArray(String[][]::new);
+    }
+}


### PR DESCRIPTION
Counterpart of https://github.com/ome/omero-web/pull/32 for relaxing minor version check from v5.5 onward.