### PR TITLE
Make sure default wss port is set

### DIFF
--- a/src/main/java/omero/gateway/LoginCredentials.java
+++ b/src/main/java/omero/gateway/LoginCredentials.java
@@ -67,9 +67,9 @@ public class LoginCredentials {
 
     /** Default websocket ports (this might be moved into omero.constants
      * in future) **/
-    private enum DefaultPort {
+    enum DefaultPort {
         WS(80), WSS(443);
-        private final int port;
+        final int port;
         DefaultPort(int port) {
             this.port = port;
         }

--- a/src/main/java/omero/gateway/ServerInformation.java
+++ b/src/main/java/omero/gateway/ServerInformation.java
@@ -115,14 +115,17 @@ public class ServerInformation {
                 // this is already a URI like wss://example.org
                 int port = this.uri.getPort();
                 this.uri = new URI(host);
-                if (port >= 0 && this.uri.getPort() < 0) {
+                if (this.uri.getPort() < 0) {
+                    if (port <= 0) {
+                        port = LoginCredentials.DefaultPort.valueOf(getProtocol().toUpperCase()).port;
+                    }
                     this.uri = new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(),
                             port, uri.getPath(), uri.getQuery(), uri.getFragment());
                 }
             }
             else {
                 int port = uri.getPort();
-                if (port < 0 && host.contains(":")) {
+                if (host.contains(":")) {
                     try {
                         String[] parts = host.split(":");
                         port = Integer.parseInt(parts[parts.length-1]);


### PR DESCRIPTION
Make sure the default websocket port is set, when calling `setHost()`.
Fixes https://github.com/ome/omero-gateway-java/issues/27
