### PR TITLE
Bump TestNG version to match other components of OMERO.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
     implementation("commons-beanutils:commons-beanutils:1.9.3")
     implementation("com.zeroc:icegrid:3.6.5")
-    testCompile("org.testng:testng:6.9.8")
+    testCompile("org.testng:testng:6.14.2")
 }
 
 configurations.all {


### PR DESCRIPTION
Seems odd for the Java Gateway to be using a different version of TestNG than other components. Can make testing with IDEs a bit of a pain.