### PR TITLE
Improve error message

### DIFF
--- a/src/main/java/omero/gateway/LoginCredentials.java
+++ b/src/main/java/omero/gateway/LoginCredentials.java
@@ -20,9 +20,7 @@
  */
 package omero.gateway;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import omero.IllegalArgumentException;
 
@@ -72,6 +70,22 @@ public class LoginCredentials {
         final int port;
         DefaultPort(int port) {
             this.port = port;
+        }
+
+        /**
+         * Get the DefaultPort for the given protocol
+         * @param protocol The protocol
+         * @return The DefaultPort
+         * @throws IllegalArgumentException If not found
+         */
+        static DefaultPort fromProtocol(String protocol) throws IllegalArgumentException {
+            String msg = protocol+" is not supported. Supported protocols: ";
+            for (DefaultPort p : DefaultPort.values()) {
+                msg += p.name();
+                if (p.name().equals(protocol.toUpperCase()))
+                    return p;
+            }
+            throw new IllegalArgumentException(msg);
         }
     }
 
@@ -142,11 +156,7 @@ public class LoginCredentials {
                 server.setPort(omero.constants.GLACIER2PORT.value);
             }
             else if (server.getPort() < 0) {
-                try {
-                    server.setPort(DefaultPort.valueOf(server.getProtocol().toUpperCase()).port);
-                } catch (IllegalArgumentException e) {
-                    // neither ws nor wss
-                }
+                server.setPort(DefaultPort.fromProtocol(server.getProtocol()).port);
             }
         }
     }

--- a/src/main/java/omero/gateway/LoginCredentials.java
+++ b/src/main/java/omero/gateway/LoginCredentials.java
@@ -22,8 +22,6 @@ package omero.gateway;
 
 import java.util.List;
 
-import omero.IllegalArgumentException;
-
 import com.google.common.collect.ImmutableList;
 
 /**

--- a/src/main/java/omero/gateway/LoginCredentials.java
+++ b/src/main/java/omero/gateway/LoginCredentials.java
@@ -64,7 +64,7 @@ public class LoginCredentials {
     /** Default websocket ports (this might be moved into omero.constants
      * in future) **/
     enum DefaultPort {
-        WS(80), WSS(443);
+        WS(80), WSS(443), HTTP(80), HTTPS(443);
         final int port;
         DefaultPort(int port) {
             this.port = port;

--- a/src/main/java/omero/gateway/LoginCredentials.java
+++ b/src/main/java/omero/gateway/LoginCredentials.java
@@ -79,7 +79,7 @@ public class LoginCredentials {
         static DefaultPort fromProtocol(String protocol) throws IllegalArgumentException {
             String msg = protocol+" is not supported. Supported protocols: ";
             for (DefaultPort p : DefaultPort.values()) {
-                msg += p.name();
+                msg += p.name()+" ";
                 if (p.name().equals(protocol.toUpperCase()))
                     return p;
             }

--- a/src/main/java/omero/gateway/ServerInformation.java
+++ b/src/main/java/omero/gateway/ServerInformation.java
@@ -117,7 +117,7 @@ public class ServerInformation {
                 this.uri = new URI(host);
                 if (this.uri.getPort() < 0) {
                     if (port <= 0) {
-                        port = LoginCredentials.DefaultPort.valueOf(getProtocol().toUpperCase()).port;
+                        port = LoginCredentials.DefaultPort.fromProtocol(getProtocol()).port;
                     }
                     this.uri = new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(),
                             port, uri.getPath(), uri.getQuery(), uri.getFragment());


### PR DESCRIPTION
Give a better error message if someone provides an unsupported URL (only `wss://...` or `ws://...` is supported).

See Issue https://github.com/ome/omero-gateway-java/issues/33
