### PR TITLE
Note the client IP address when connecting to the server.

### DIFF
--- a/src/main/java/omero/gateway/Gateway.java
+++ b/src/main/java/omero/gateway/Gateway.java
@@ -24,6 +24,7 @@ package omero.gateway;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -1071,6 +1072,11 @@ public class Gateway implements AutoCloseable {
                 secureClient = new client(c.getServer().getHost());
         }
         secureClient.setAgent(c.getApplicationName());
+        try {
+            secureClient.setIP(InetAddress.getLocalHost().getHostAddress());
+        } catch (UnknownHostException uhe) {
+            // doesn't much matter
+        }
         ServiceFactoryPrx entryEncrypted = null;
         
         boolean connected = false;


### PR DESCRIPTION
This should allow Insight to behave like Web in allowing the server to note a client IP on login. It will probably note a useful IP from Windows machines though from Linux it's more likely to simply note the local loopback IP which is at least no worse than not noting anything! It *is* possible to write fancier code to try to get a better IP even from Linux but probably not worth our effort right now. The IPs are noted in the database in `session.userip`.