### PR TITLE
Prepare changelog for releasing OMERO 5.6.3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
+5.6.5 (September 2020)
+----------------------
+
+- Bump omero-blitz version to 5.5.8
+
 5.6.4 (July 2020)
 -----------------
 
 - Improve error message ([#34](https://github.com/ome/omero-gateway-java/pull/34)
 - Note the client IP address when connecting to the server ([#36](https://github.com/ome/omero-gateway-java/pull/36)
 - Add missing license file ([#37](https://github.com/ome/omero-gateway-java/pull/37)
+- Bump omero-blitz version to 5.5.7
 
 5.6.3 (March 2020)
 ------------------


### PR DESCRIPTION
Update the changelog in preparation for releasing OMERO 5.6.3.

Stated versions are those to which I propose setting dependencies then naming the tag.