### PR TITLE
Fallback if args login doesn't work

### DIFF
--- a/src/main/java/omero/gateway/Gateway.java
+++ b/src/main/java/omero/gateway/Gateway.java
@@ -1099,17 +1099,25 @@ public class Gateway implements AutoCloseable {
             }
         }
         if (!connected) {
-            try {
-                if (args != null) {
+            if (args != null) {
+                try {
                     entryEncrypted = secureClient.createSession();
-                } else {
+                } catch(Exception e) {
+                    log.warn(this, new LogMessage(
+                            "Could not login with command line arguments.", e));
                     entryEncrypted = secureClient.createSession(c.getUser()
                             .getUsername(), c.getUser().getPassword());
                 }
-            } catch (Exception e1) {
-                // close the session again before passing on the exception
-                secureClient.closeSession();
-                throw e1;
+            }
+            if (entryEncrypted == null) {
+                try {
+                    entryEncrypted = secureClient.createSession(c.getUser()
+                            .getUsername(), c.getUser().getPassword());
+                } catch (Exception e1) {
+                    // close the session again before passing on the exception
+                    secureClient.closeSession();
+                    throw e1;
+                }
             }
         }
 

--- a/src/main/java/omero/gateway/Gateway.java
+++ b/src/main/java/omero/gateway/Gateway.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015-2020 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -1105,8 +1105,6 @@ public class Gateway implements AutoCloseable {
                 } catch(Exception e) {
                     log.warn(this, new LogMessage(
                             "Could not login with command line arguments.", e));
-                    entryEncrypted = secureClient.createSession(c.getUser()
-                            .getUsername(), c.getUser().getPassword());
                 }
             }
             if (entryEncrypted == null) {


### PR DESCRIPTION
Fallback to the "normal" login if the cmd line args login doesn't work. This would be a "fix" for https://github.com/ome/omero-insight/issues/224 for now, until proper character escaping is implemented.

Can be tested with Insight. I created a user 'pwtest' on merge-ci with password ' test' (leading space!).
Check that you can login with merge-ci build, and that it fails with current release version of Insight.
Check Insight log, should include the error messages of failed first attempt.

/cc @jburel 

