### PR TITLE
Add method to get PlaneInfos

### DIFF
--- a/src/main/java/omero/gateway/facility/MetadataFacility.java
+++ b/src/main/java/omero/gateway/facility/MetadataFacility.java
@@ -32,7 +32,11 @@ import java.util.Arrays;
 import omero.ServerError;
 import omero.api.IQueryPrx;
 import omero.gateway.model.FilesetData;
+import omero.gateway.model.PixelsData;
+import omero.gateway.model.PlaneInfoData;
 import omero.model.FilesetI;
+import omero.model.PlaneInfo;
+import omero.sys.Parameters;
 import org.apache.commons.collections.CollectionUtils;
 
 import omero.api.IMetadataPrx;
@@ -301,6 +305,35 @@ public class MetadataFacility extends Facility {
             handleException(this, t, "Could not get the file paths.");
         }
         return Collections.emptyList();
+    }
+
+    /**
+     * Get the plane infos.
+     * @param ctx The SecurityContext
+     * @param pix The PixelsData
+     * @return See above
+     * @throws DSOutOfServiceException
+     * @throws DSAccessException
+     */
+    public List<PlaneInfoData> getPlaneInfos(SecurityContext ctx, PixelsData pix) throws DSOutOfServiceException,
+            DSAccessException {
+        List<PlaneInfoData> result = new ArrayList<>();
+        try {
+            ParametersI p = new ParametersI();
+            p.addLong("id", pix.getId());
+            List<IObject> planeinfos = gateway.getQueryService(ctx)
+                .findAllByQuery("select info from PlaneInfo as info " +
+                                "join fetch info.deltaT as dt " +
+                                "join fetch info.exposureTime as et " +
+                                "where info.pixels.id = :id",
+                        p);
+            for (IObject obj : planeinfos) {
+                result.add(new PlaneInfoData((PlaneInfo) obj));
+            }
+        } catch (Throwable th) {
+            handleException(this, th, "Could not get the planeinfos.");
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/omero/gateway/model/DataObject.java
+++ b/src/main/java/omero/gateway/model/DataObject.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -50,6 +50,7 @@ import omero.model.Image;
 import omero.model.LongAnnotation;
 import omero.model.Permissions;
 import omero.model.Pixels;
+import omero.model.PlaneInfo;
 import omero.model.Plate;
 import omero.model.Project;
 import omero.model.Screen;
@@ -583,6 +584,17 @@ public abstract class DataObject {
      */
     public Channel asChannel() {
         return (Channel) asIObject();
+    }
+
+    /**
+     * Returns the hosted IObject as a PlaneInfo. Not null; may throw class-cast
+     * exception
+     *
+     * @throws ClassCastException
+     * @return See above
+     */
+    public PlaneInfo asPlaneInfo() {
+        return (PlaneInfo) asIObject();
     }
 
     /**

--- a/src/main/java/omero/gateway/model/PlaneInfoData.java
+++ b/src/main/java/omero/gateway/model/PlaneInfoData.java
@@ -1,0 +1,105 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2021 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------*/
+package omero.gateway.model;
+
+import omero.model.Length;
+import omero.model.PlaneInfo;
+import omero.model.PlaneInfoI;
+import omero.model.Time;
+
+public class PlaneInfoData extends DataObject {
+
+    public PlaneInfoData() {
+        setDirty(true);
+        setValue(new PlaneInfoI());
+    }
+
+    public PlaneInfoData(PlaneInfo info) {
+        if (info == null) {
+            throw new IllegalArgumentException("The object cannot be null.");
+        }
+        setValue(info);
+    }
+
+    public Time getDeltaT() {
+        return asPlaneInfo().getDeltaT();
+    }
+
+    public Time getExposureTime() {
+        return asPlaneInfo().getExposureTime();
+    }
+
+    public Length getPositionX() {
+        return asPlaneInfo().getPositionX();
+    }
+
+    public Length getPositionY() {
+        return asPlaneInfo().getPositionY();
+    }
+
+    public Length getPositionZ() {
+        return asPlaneInfo().getPositionZ();
+    }
+
+    public int getTheC() {
+        return asPlaneInfo().getTheC().getValue();
+    }
+
+    public int getTheT() {
+        return asPlaneInfo().getTheT().getValue();
+    }
+
+    public int getTheZ() {
+        return asPlaneInfo().getTheZ().getValue();
+    }
+
+
+    public void setDeltaT(Time theDeltaT) {
+        asPlaneInfo().setDeltaT(theDeltaT);
+    }
+
+    public void setExposureTime(Time theExposureTime) {
+        asPlaneInfo().setExposureTime(theExposureTime);
+    }
+
+    public void setPositionX(Length thePositionX) {
+        asPlaneInfo().setPositionX(thePositionX);
+    }
+
+    public void setPositionY(Length thePositionY) {
+        asPlaneInfo().setPositionY(thePositionY);
+    }
+
+    public void setPositionZ(Length thePositionZ) {
+        asPlaneInfo().setPositionZ(thePositionZ);
+    }
+
+    public void setTheC(int theTheC) {
+        asPlaneInfo().setTheC(omero.rtypes.rint(theTheC));
+    }
+
+    public void setTheT(int theTheT) {
+        asPlaneInfo().setTheT(omero.rtypes.rint(theTheT));
+    }
+
+    public void setTheZ(int theTheZ) {
+        asPlaneInfo().setTheZ(omero.rtypes.rint(theTheZ));
+    }
+}


### PR DESCRIPTION
Add a similar method to the [copyPlaneInfo](https://github.com/ome/omero-py/blob/94b4be90f85f8ccaef02ceebc75320cf1b70db38/src/omero/gateway/__init__.py#L7372) method of Python BlitzGateway. Should fix https://github.com/ome/omero-gateway-java/issues/54 .

**Todo:** ~~Still needs integration test.~~ Done