### PR TITLE
Remove joinsession

### DIFF
--- a/src/main/java/omero/gateway/Gateway.java
+++ b/src/main/java/omero/gateway/Gateway.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015-2021 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2022 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -1019,22 +1019,7 @@ public class Gateway implements AutoCloseable {
             // doesn't much matter
         }
         ServiceFactoryPrx entryEncrypted = null;
-        
-        boolean connected = false;
-        boolean isSessionLogin = false;
-        if (isSessionID(username)) {
-            try {
-                entryEncrypted = secureClient.joinSession(username);
-                connected = true;
-                isSessionLogin = true;
-            } catch (Exception e) {
-                // Although username looks like a session ID it apparently isn't
-                // one.
-                log.warn(this, new LogMessage("Could not join session "
-                        + username + " , trying username/password login next.",
-                        e));
-            }
-        }
+
         if (!connected) {
             if (args != null) {
                 try {
@@ -1090,7 +1075,7 @@ public class Gateway implements AutoCloseable {
         keepAliveExecutor = new ScheduledThreadPoolExecutor(1);
         keepAliveExecutor.scheduleWithFixedDelay(r, 60, 60, TimeUnit.SECONDS);
         
-        return new SessionWrapper(secureClient, isSessionLogin);
+        return new SessionWrapper(secureClient, isSessionID(username));
     }
 
     /**

--- a/src/main/java/omero/gateway/Gateway.java
+++ b/src/main/java/omero/gateway/Gateway.java
@@ -367,69 +367,6 @@ public class Gateway implements AutoCloseable {
     }
 
     /**
-     * @deprecated This method will be removed in future (never used).
-     *
-     * Tries to rejoin the session.
-     *
-     * @return See above.
-     */
-    @Deprecated
-    public boolean joinSession() {
-        try {
-            isNetworkUp(false); // Force re-check to prevent hang
-        } catch (Exception e) {
-            // no need to handle the exception.
-        }
-        boolean networkup = isNetworkUp(false);
-        connected = false;
-        if (!networkup) {
-            if (log != null) {
-                log.warn(this, "Network is down");
-            }
-            return false;
-        }
-        List<Connector> connectors = removeAllConnectors();
-        Iterator<Connector> i = connectors.iterator();
-        Connector c;
-        int index = 0;
-        while (i.hasNext()) {
-            c = i.next();
-            try {
-                if (log != null)
-                    log.debug(this, "joining the session ");
-                c.joinSession();
-                groupConnectorMap.put(c.getGroupID(), c);
-            } catch (Throwable t) {
-                if (log != null)
-                    log.error(this,
-                        new LogMessage("Failed to join the session ", t));
-                // failed to join so we create a new one, first we shut down
-                try {
-                    c.shutDownServices(true);
-                    c.close(networkup);
-                } catch (Throwable e) {
-                    if (log != null)
-                        log.error(this, new LogMessage(
-                            "Failed to close the session ", t));
-                }
-                if (!groupConnectorMap.containsKey(c.getGroupID())) {
-                    try {
-                        createConnector(new SecurityContext(c.getGroupID()),
-                                false);
-                    } catch (Exception e) {
-                        if (log != null)
-                            log.error(this, new LogMessage(
-                                "Failed to create connector ", e));
-                        index++;
-                    }
-                }
-            }
-        }
-        connected = index == 0;
-        return connected;
-    }
-
-    /**
      * Check if the Gateway is still connected to the server
      * 
      * @return See above.

--- a/src/main/java/omero/gateway/JoinSessionCredentials.java
+++ b/src/main/java/omero/gateway/JoinSessionCredentials.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2017 University of Dundee. All rights reserved.
+ *  Copyright (C) 2017-2022 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -25,10 +25,13 @@ import java.util.UUID;
 /**
  * Holds all necessary information needed for joining an active OMERO server
  * session
- * 
+ *
+ * @deprecated Use LoginCredentials and use session id as username and password.
+ *
  * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
  *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
  */
+@Deprecated()
 public class JoinSessionCredentials extends LoginCredentials {
 
     /**


### PR DESCRIPTION
Following discussion https://github.com/ome/openmicroscopy/pull/6319 . Removes the calls to `client.joinSession`, only `client.createSession` is used. The check for session id login is kept, because the gateway uses it to decide if the session can be closed on disconnect.

The implications for clients are:
- `Gateway.joinSession` method doesn't exist any longer
- For session ID login the ID has to be passed as username and password. Before username was enough.

(replaces https://github.com/ome/omero-gateway-java/pull/62 )
