### PR TITLE
Fix warning in javadoc

### DIFF
--- a/src/main/java/omero/gateway/util/Links.java
+++ b/src/main/java/omero/gateway/util/Links.java
@@ -42,7 +42,7 @@ public class Links {
 
     /**
      * Get the Link class for a certain child parent combination, e.g. parent:
-     * DatasetData, child: ImageData => omero.model.DatasetImageLinkI
+     * DatasetData, child: ImageData =&gt; omero.model.DatasetImageLinkI
      *
      * @param parent The parent
      * @param child  The child


### PR DESCRIPTION
This should fix 
```
> Task :omero-gateway-java:javadoc
/home/omero/workspace/OMERO-build-build/omero-gateway-java/src/main/java/omero/gateway/util/Links.java:45: warning - invalid usage of tag >
1 warning
```