### PR TITLE
Replace user/pass with sessionId after successful login

### DIFF
--- a/src/main/java/omero/gateway/Gateway.java
+++ b/src/main/java/omero/gateway/Gateway.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015-2022 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2023 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -294,6 +294,7 @@ public class Gateway implements AutoCloseable {
         try {
             SessionWrapper session = createSession(c);
             loggedInUser = login(session, c);
+            c.setSessionId(session.client.getSessionId());
             connected = true;
             return loggedInUser;
         } catch (CannotCreateSessionException e) {

--- a/src/main/java/omero/gateway/LoginCredentials.java
+++ b/src/main/java/omero/gateway/LoginCredentials.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015-2017 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2023 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -286,4 +286,12 @@ public class LoginCredentials {
         this.checkVersion = checkVersion;
     }
 
+    /**
+     * Replaces username and password with the sessionId
+     * @param sessionId The sessionId
+     */
+    public void setSessionId(String sessionId) {
+        this.user.setUsername(sessionId);
+        this.user.setPassword(sessionId);
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/ome/omero-gateway-java/issues/79 .
After successful login the username and password will be replaced by the sessionId, so that the password is not held in memory any longer. With the sessionId as username/password it is still possible to re-connect after a connection loss without having the password.
It only partially addresses the issue. There's no point in replacing the password String with char[] unless it can be done everywhere in the code. But when calling the Java API the method requires a String anyway.
