### PR TITLE
Fix order of the directory separators when downloading an image

### DIFF
--- a/src/main/java/omero/gateway/facility/TransferFacilityHelper.java
+++ b/src/main/java/omero/gateway/facility/TransferFacilityHelper.java
@@ -135,7 +135,7 @@ public class TransferFacilityHelper {
                 for (FilesetEntry fse: fs.copyUsedFiles()) {
                     OriginalFile of = fse.getOriginalFile();
                     String ofDir = of.getPath().getValue().replace(repoPath, "");
-                    File outDir = new File(targetPath+File.separator+ofDir+File.separator+fs_dir);
+                    File outDir = new File(targetPath+File.separator+fs_dir+File.separator+ofDir);
                     outDir.mkdirs();
                     File saved = saveOriginalFile(context, of, outDir);
                     if (saved != null)


### PR DESCRIPTION
Fixes #89

Ensure the internal repository path is applied after the fileset separator so that the internal structure is preserved and the data can be read by Bio-Formats.

The original change was introduced in https://github.com/ome/omero-gateway-java/pull/85 and exposed in OMERO.insight 5.8.4.

To test the fix, import filesets of different formats (see below) into OMERO and download them using the Java gateway i.e. either using OMERO.insight built with this change or with a standalone Java client like https://github.com/ome/minimal-omero-client. Without this change, the single-file filesets should be stored in a folder called `Fileset_<id>` but multi-file filesets will have their hierarchy inverted i.e. data `<internal_folder>/Fileset_<id>`.

With this change Bio-Formats should be able to read any downloaded fileset either using the command-line tools (`showinf`) or re-importing the data into the same server.

Several file formats should likely be tested to confirm the fix is working in all scenarios. Excluding the HCS formats (which could also be tested but might require more time), minimally, the following set of formats should cover a set of layouts:
- OME-TIFF (single file)
- OME-TIFF (multi file)
- VSI (multi file with multiple directories)
- FV1000 (multi file with directory)