### PR TITLE
Bump org.openmicroscopy:omero-blitz from 5.8.2 to 5.8.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    api("org.openmicroscopy:omero-blitz:5.8.2")
+    api("org.openmicroscopy:omero-blitz:5.8.3")
 
     implementation("commons-beanutils:commons-beanutils:1.9.3")
     implementation("com.zeroc:icegrid:3.6.5")


### PR DESCRIPTION
See https://github.com/ome/omero-blitz/releases/tag/v5.8.3 for the list of changes