### PR TITLE
Bump org.openmicroscopy:omero-blitz from 5.8.4 to 5.8.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ compileJava {
 }
 
 dependencies {
-    api("org.openmicroscopy:omero-blitz:5.8.4")
+    api("org.openmicroscopy:omero-blitz:5.8.5")
 
     implementation("commons-beanutils:commons-beanutils:1.9.3")
     implementation("org.apache.commons:commons-lang3:3.18.0")


### PR DESCRIPTION
See https://github.com/ome/omero-blitz/releases/tag/v5.8.5